### PR TITLE
fix: adjust brackets on cognito token_validity_units

### DIFF
--- a/src/client.tf
+++ b/src/client.tf
@@ -71,14 +71,13 @@ resource "aws_cognito_user_pool_client" "client" {
 
   dynamic "token_validity_units" {
     for_each = length(lookup(element(local.clients, count.index), "token_validity_units", [])) == 0 ? [] : [lookup(element(local.clients, count.index), "token_validity_units", null)]
-  }
 
-  content {
-    access_token  = lookup(token_validity_units.value, "access_token", null)
-    id_token      = lookup(token_validity_units.value, "id_token", null)
-    refresh_token = lookup(token_validity_units.value, "refresh_token", null)
+    content {
+      access_token  = lookup(token_validity_units.value, "access_token", null)
+      id_token      = lookup(token_validity_units.value, "id_token", null)
+      refresh_token = lookup(token_validity_units.value, "refresh_token", null)
+    }
   }
-
 
   depends_on = [
     aws_cognito_resource_server.resource,


### PR DESCRIPTION
## what

- Adjusts bracket enclosures for the dynamic content block for `token_validity_units`

## usage

```sh
atmos terraform plan cognito -s <stack>
```

## testing

- Successfully ran `terraform validate component cognito -s <stack>
- Successfully ran `terraform plan`

## why

- Fixes #13 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Restructured Terraform configuration for AWS Cognito User Pool Client token validity units to improve code organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->