### PR TITLE
fix: correct validation for compromised credentials actions

### DIFF
--- a/src/variables.tf
+++ b/src/variables.tf
@@ -693,10 +693,7 @@ variable "compromised_credentials_risk_configuration" {
   validation {
     condition = (
       var.compromised_credentials_risk_configuration.actions == null ||
-      (
-        contains(keys(var.compromised_credentials_risk_configuration.actions), "event_action") &&
-        length(trimspace(var.compromised_credentials_risk_configuration.actions.event_action)) > 0
-      )
+      try(length(trimspace(var.compromised_credentials_risk_configuration.actions.event_action)) > 0, false)
     )
     error_message = "When compromised_credentials_risk_configuration.actions is provided, it must include a non-empty 'event_action' field. Valid values are 'BLOCK' or 'NO_ACTION'."
   }


### PR DESCRIPTION
## what
* Fix validation block in `compromised_credentials_risk_configuration` variable to handle null `actions` attribute
* Wrap attribute access in `try()` to prevent Terraform evaluation errors when `actions` is null
* Remove redundant `contains(keys(...))` check since `event_action` is a required field in the type definition

## why
* Terraform doesn't short-circuit `||` operators during validation - it evaluates both sides before applying the logical operation
* When `actions` is `null`, calling `keys()` on null and accessing `.event_action` on null causes "Invalid function argument" and "Attempt to get attribute from null value" errors
* The `try()` function gracefully returns `false` when the expression fails, allowing the first condition (`actions == null`) to pass validation

## references
* [Terraform try() function documentation](https://developer.hashicorp.com/terraform/language/functions/try)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation error handling to more robustly manage edge cases and missing configuration values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->