### PR TITLE
chore: migrate Renovate preset to recommended

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "prConcurrentLimit": 5,
   "extends": [
-    "config:base"
+    "config:recommended"
   ]
 }


### PR DESCRIPTION
## What
- Migrates Renovate's deprecated `config:base` preset to `config:recommended`.
- Preserves the existing `prConcurrentLimit` and all other settings.

## Why
Renovate's Dependency Dashboard for this repo reports **Config Migration Needed** in #3.

## Validation
- Parsed `.github/renovate.json` as JSON.
- Ran `git diff --check`.
- Skipped `atmos test run`: this repository's `AGENTS.md` says the tests can create/destroy AWS resources and incur cost.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to enforce stricter update rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->