### PR TITLE
fix: ignore Cognito-injected SAML provider_details keys to stop perpetual drift

### DIFF
--- a/src/identity-provider.tf
+++ b/src/identity-provider.tf
@@ -9,4 +9,18 @@ resource "aws_cognito_identity_provider" "identity_provider" {
   attribute_mapping = lookup(element(var.identity_providers, count.index), "attribute_mapping", {})
   idp_identifiers   = lookup(element(var.identity_providers, count.index), "idp_identifiers", [])
   provider_details  = lookup(element(var.identity_providers, count.index), "provider_details", {})
+
+  lifecycle {
+    # For SAML providers configured via `MetadataURL`, Cognito derives and injects
+    # additional `provider_details` keys that are returned by the API but are never
+    # present in the input `provider_details` map: the active encryption certificate
+    # and the SSO/SLO redirect binding URIs. Without ignoring them, every plan tries
+    # to remove them and Cognito re-adds them, producing perpetual drift. Ignore only
+    # these server-managed keys so genuine changes (e.g. `MetadataURL`) still apply.
+    ignore_changes = [
+      provider_details["ActiveEncryptionCertificate"],
+      provider_details["SSORedirectBindingURI"],
+      provider_details["SLORedirectBindingURI"],
+    ]
+  }
 }


### PR DESCRIPTION
## what

- Add `lifecycle.ignore_changes` on `aws_cognito_identity_provider.identity_provider` for three `provider_details` keys that AWS Cognito populates itself: `ActiveEncryptionCertificate`, `SSORedirectBindingURI`, and `SLORedirectBindingURI`.

## why

For SAML identity providers configured via `MetadataURL`, Cognito fetches the IdP metadata and **injects** derived keys into `provider_details` — the active encryption certificate and the SSO/SLO redirect binding URIs. These are returned by `DescribeIdentityProvider` but are never present in the configured `provider_details` map (which typically only contains `MetadataURL`).

The result is **perpetual drift**: every `plan` proposes removing the injected keys, `apply` sends the update without them, and Cognito immediately re-adds them — so `aws_cognito_identity_provider` shows a recurring in-place update that never converges.

Example diff seen on every plan of an unchanged SAML provider:

```text
# aws_cognito_identity_provider.identity_provider[0] will be updated in-place
    ~ provider_details = {
        - "ActiveEncryptionCertificate" = "MIIC..."                     -> null
        - "SSORedirectBindingURI"       = "https://login.microsoftonline.com/.../saml2" -> null
        - "SLORedirectBindingURI"       = "https://login.microsoftonline.com/.../saml2" -> null
      }
```

Scoping `ignore_changes` to exactly these three server-managed keys stops the drift while leaving genuine `provider_details` changes (e.g. updating `MetadataURL`) fully manageable.

## notes

- **Safe for non-SAML providers.** `ignore_changes` on a map key that is absent (OIDC / social providers, which don't have these keys) is a no-op, so this does not affect them.
- OIDC providers configured via `oidc_issuer` have their own analogous Cognito-derived keys (`attributes_url`, `authorize_url`, `jwks_uri`, `token_url`); those could be added the same way in a follow-up if there's demand — kept out of this PR to keep it to the verified SAML case.
- Verified against a live EntraID (Azure AD) SAML provider: after the change the `identity_provider` resource drops out of the plan entirely (0 changes) with no apply required, since `ignore_changes` is a plan-time behavior.

## references

- `terraform fmt` clean; `terraform validate` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented repeated infrastructure drift for Cognito-managed SAML provider encryption certificate and SSO/SLO redirect settings.
  * Preserved detection of changes to other SAML provider configuration details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->